### PR TITLE
Use hierarchies instead of allRows()

### DIFF
--- a/examples/js-areachart-d3/src/render.js
+++ b/examples/js-areachart-d3/src/render.js
@@ -94,28 +94,31 @@ export async function render(state, mod, dataView, windowSize, chartType, rounde
     } else {
         mod.controls.errorOverlay.hide("rowCount");
     }
+    
+    const colorHierarchy = await dataView.hierarchy("Color");
+    const xHierarchy = await dataView.hierarchy("X");
 
-    const allRows = await dataView.allRows();
-    if (allRows == null) {
+    // By awaiting one hierarchy root, all rows will be fetched.
+    const colorRoot = await colorHierarchy.root();
+    const xRoot = await xHierarchy.root();
+    if (colorRoot == null) {
         // Return and wait for next call to render when reading data was aborted.
         // Last rendered data view is still valid from a users perspective since
         // a document modification was made during a progress indication.
         return;
     }
 
-    const colorHierarchy = await dataView.hierarchy("Color");
-    const xHierarchy = await dataView.hierarchy("X");
+    const colorLeaves = colorRoot.leaves();
+    const xLeaves = xRoot.leaves();
+
     const colorSeries = buildColorSeries(
-        (await colorHierarchy.root()).leaves(),
-        (await xHierarchy.root()).leaves(),
+        colorLeaves,
+        xLeaves,
         !xHierarchy.isEmpty,
         !!(await dataView.continuousAxis("Y")),
         chartType.value(),
         gapfill.value()
     );
-
-    const xLeaves = (await xHierarchy.root()).leaves();
-    const colorLeaves = (await colorHierarchy.root()).leaves();
 
     const xAxisMeta = await mod.visualization.axis("X");
     const yAxisMeta = await mod.visualization.axis("Y");

--- a/examples/js-dev-barchart-googlecharts/src/main.js
+++ b/examples/js-dev-barchart-googlecharts/src/main.js
@@ -197,21 +197,9 @@ Spotfire.initialize(async (mod) => {
             const { row, column } = selection;
             const xIndex = row;
             const colorIndex = (column - 1) / 2;
-            selectRow(xIndex, colorIndex);
-        });
 
-        /**
-         * Select a row by `x` and `color` indexes.
-         */
-        function selectRow(xIndex, colorIndex) {
-            colorRoot.rows().forEach((row) => {
-                var rowColorIndex = !colorHierarchy.isEmpty ? row.categorical("Color").leafIndex : 0;
-                var rowXIndex = !xHierarchy.isEmpty ? row.categorical("X").leafIndex : 0;
-                if (rowXIndex == xIndex && rowColorIndex == colorIndex) {
-                    row.mark();
-                }
-            });
-        }
+            intersection(xLeafNodes[xIndex].rows(), colorLeafNodes[colorIndex].rows()).forEach((r) => r.mark());
+        });
 
         /**
          * Add click events for background and both axes
@@ -301,6 +289,10 @@ Spotfire.initialize(async (mod) => {
         function popoutChangeHandler({ name, value }) {
             name == orientation.name && orientation.set(value);
             name == stacking.name && stacking.set(value);
+        }
+
+        function intersection(rows1, rows2) {
+            return rows1.filter((r) => rows2.indexOf(r) > -1);
         }
 
         /**

--- a/examples/js-dev-barchart-googlecharts/src/main.js
+++ b/examples/js-dev-barchart-googlecharts/src/main.js
@@ -57,20 +57,18 @@ Spotfire.initialize(async (mod) => {
         mod.controls.errorOverlay.hide();
 
         /**
-         * Get rows from dataView
+         * Get the color hierarchy.
          */
-        const rows = await dataView.allRows();
-        if (rows == null) {
+        const colorHierarchy = await dataView.hierarchy("Color");
+        const colorRoot = await colorHierarchy.root();
+
+        if (colorRoot == null) {
             // User interaction caused the data view to expire.
             // Don't clear the mod content here to avoid flickering.
             return;
         }
 
-        /**
-         * Get the color hierarchy.
-         */
-        const colorHierarchy = await dataView.hierarchy("Color");
-        const colorLeafNodes = (await colorHierarchy.root()).leaves();
+        const colorLeafNodes = colorRoot.leaves();
         const colorDomain = colorHierarchy.isEmpty
             ? ["All Values"]
             : colorLeafNodes.map((node) => node.formattedPath());
@@ -206,7 +204,7 @@ Spotfire.initialize(async (mod) => {
          * Select a row by `x` and `color` indexes.
          */
         function selectRow(xIndex, colorIndex) {
-            rows.forEach((row) => {
+            colorRoot.rows().forEach((row) => {
                 var rowColorIndex = !colorHierarchy.isEmpty ? row.categorical("Color").leafIndex : 0;
                 var rowXIndex = !xHierarchy.isEmpty ? row.categorical("X").leafIndex : 0;
                 if (rowXIndex == xIndex && rowColorIndex == colorIndex) {

--- a/examples/js-dev-starter-ie11/src/main.js
+++ b/examples/js-dev-starter-ie11/src/main.js
@@ -4,14 +4,15 @@
  * in the license file that is distributed with this file.
  */
 
+//@ts-check - Get type warnings from the TypeScript language server. Remove if not wanted
+
 // Manually import the array polyfills because the API is using functions not supported in IE11.
 import "core-js/es/array";
 
-//@ts-check - Get type warnings from the TypeScript language server. Remove if not wanted
 /**
  * Get access to the Spotfire Mod API by providing a callback to the initialize method.
  */
-Spotfire.initialize(async (mod) => {
+window.Spotfire.initialize(async (mod) => {
     /**
      * Create the read function.
      */
@@ -47,10 +48,12 @@ Spotfire.initialize(async (mod) => {
         mod.controls.errorOverlay.hide();
 
         /**
-         * Get rows from dataView
+         * Get the hierarchy of the categorical X-axis.
          */
-        const rows = await dataView.allRows();
-        if (rows == null) {
+        const xHierarchy = await dataView.hierarchy("X");
+        const xRoot = await xHierarchy.root();
+
+        if (xRoot == null) {
             // User interaction caused the data view to expire.
             // Don't clear the mod content here to avoid flickering.
             return;
@@ -61,7 +64,7 @@ Spotfire.initialize(async (mod) => {
          */
         const container = document.querySelector("#mod-container");
         container.textContent = `windowSize: ${windowSize.width}x${windowSize.height}\r\n`;
-        container.textContent += `should render: ${rows.length} rows\r\n`;
+        container.textContent += `should render: ${xRoot.rows().length} rows\r\n`;
         container.textContent += `${prop.name}: ${prop.value()}`;
 
         /**

--- a/examples/js-dev-starter/src/main.js
+++ b/examples/js-dev-starter/src/main.js
@@ -46,10 +46,12 @@ Spotfire.initialize(async (mod) => {
         mod.controls.errorOverlay.hide();
 
         /**
-         * Get rows from dataView
+         * Get the hierarchy of the categorical X-axis.
          */
-        const rows = await dataView.allRows();
-        if (rows == null) {
+        const xHierarchy = await dataView.hierarchy("X");
+        const xRoot = await xHierarchy.root();
+
+        if (xRoot == null) {
             // User interaction caused the data view to expire.
             // Don't clear the mod content here to avoid flickering.
             return;
@@ -60,7 +62,7 @@ Spotfire.initialize(async (mod) => {
          */
         const container = document.querySelector("#mod-container");
         container.textContent = `windowSize: ${windowSize.width}x${windowSize.height}\r\n`;
-        container.textContent += `should render: ${rows.length} rows\r\n`;
+        container.textContent += `should render: ${xRoot.rows().length} rows\r\n`;
         container.textContent += `${prop.name}: ${prop.value()}`;
 
         /**

--- a/examples/ts-dev-gauge-googlecharts/src/main.ts
+++ b/examples/ts-dev-gauge-googlecharts/src/main.ts
@@ -59,7 +59,7 @@ Spotfire.initialize(async (mod) => {
         let gauges = gauge.element.getElementsByTagName("td");
         categoryRoot.leaves().forEach((leaf, index) => {
             gauges[index].style.background =
-                leaf.rows()[0]?.isMarked() && marking
+                marking && leaf.rows().filter(r => r.isMarked()).length
                     ? "radial-gradient(" + marking.colorHexCode + " 50%, transparent 100%)"
                     : "transparent";
         });


### PR DESCRIPTION
The preferred way to read and traverse a mod's DataView is via its hierarchies. To foster usage of the hierarchy API, the `allRows()` method should be used more sparingly in the examples.

In this pull request, the examples have been modified to primarily use the hierarchy API to read rows and to check whether they were completely read or not.