### PR TITLE
Animated bubble chart refactoring

### DIFF
--- a/catalog/animated-bubble-chart/src/animationControl.ts
+++ b/catalog/animated-bubble-chart/src/animationControl.ts
@@ -1,361 +1,111 @@
-import * as d3 from "d3";
 import { Frame, FrameFactory } from "./index";
 import { continueOnIdle } from "./interactionLock";
 import { throttle } from "./modutils";
 
-const playButtonSvg = document.querySelector("#play_button")?.lastChild!;
-const pauseButtonSvg = document.querySelector("#pause_button")?.lastChild!;
-const animationSpeedButtonSvg = document.querySelector(
-    "#animation_speed_button g"
-)!;
-const speedButtonSize = 24,
-    playButtonSize = 16,
-    padding = 8,
-    progressHeight = 6,
-    progressX =
-        (Math.max(speedButtonSize, playButtonSize) - progressHeight) / 2;
 
-type Setup = (animationControl: AnimationControl) => Render;
-type Render = (frame: Frame, animationSpeed: number) => void;
+type SetupVisualization = (animationControl: AnimationControl) => RenderFrame;
+type RenderFrame = (frame: Frame, animationSpeed: number) => void;
 
-export interface AnimationControl {
-    update(frames: FrameFactory[], onRender: Setup): void;
-    setIndex(index: number): void;
+/**
+ * The Animation control class is responsible for keeping track of the animation state and drive the rendering of the visualization.
+ */
+export class AnimationControl {
+    private frames: FrameFactory[] = [];
+    private renderFrame: RenderFrame = () => {};
+    private throttleRender = throttle(() => this.render());
 
-    visible(): boolean;
-    isPlaying(): boolean;
-    isPlaying(playing: boolean): void;
-    speed(): number;
-    speed(s: number): void;
-    domain(): [number, number];
-    currentIndex(): number;
-}
+    private animationIndex = 0;
+    private animationSpeed = 500;
+    private defaultSpeed = 500;
+    private playing = false;
+    private timer: any = null;
 
-export function animationControl(animationSpeedProperty: {
-    set: (value: number) => void;
-}): AnimationControl {
-    let frames: FrameFactory[] = [];
-    let onRender: Render = () => {};
-    let throttleRender = throttle(render);
+    constructor(private speedProperty: { set(v: any): void }) {}
 
-    let animationIndex = 0;
-    let speed = 500;
-    let defaultSpeed = 500;
-    let playing = false;
-    let timer: any = null;
-
-    let instance: AnimationControl = {
-        update(_frames: FrameFactory[], setupVisualization) {
-            frames = _frames;
-            onRender = setupVisualization(instance);
-            render();
-        },
-        isPlaying(setter?: boolean) {
-            if (setter != undefined) {
-                speed = defaultSpeed;
-                if (setter) {
-                    play();
-                } else {
-                    pause();
-                }
-                throttleRender();
-            }
-
-            return playing;
-        },
-        currentIndex() {
-            return animationIndex;
-        },
-        domain() {
-            return [0, frames.length - 1];
-        },
-        speed(s?: number) {
-            if (s != undefined) {
-                animationSpeedProperty.set(s);
-                defaultSpeed = s;
-                speed = s;
-            }
-
-            return defaultSpeed;
-        },
-        setIndex(i) {
-            pause();
-            animationIndex = i;
-            speed = 50;
-            throttleRender();
-        },
-        visible() {
-            return frames.length > 1;
-        },
-    };
-
-    function render() {
-        if (animationIndex >= frames.length) {
-            animationIndex = 0;
-        }
-
-        const frame = frames[animationIndex];
-        if(!frame.bubbles) {
-            frame.bubbles =  frame.bubbleFactory();
-        }
-
-        onRender((frame as Frame) || { name: "", bubbles: [] }, speed);
+    update(frames: FrameFactory[], setupVisualization: SetupVisualization) {
+        this.frames = frames;
+        this.renderFrame = setupVisualization(this);
+        this.render();
     }
 
-    function pause() {
-        playing = false;
-        clearTimeout(timer);
+    isPlaying(setter?: boolean) {
+        if (setter != undefined) {
+            this.animationSpeed = this.defaultSpeed;
+            if (setter) {
+                this.play();
+            } else {
+                this.pause();
+            }
+            this.throttleRender();
+        }
+
+        return this.playing;
     }
 
-    function play() {
-        playing = true;
-        render();
-        timer = setTimeout(async function next() {
-            if (!playing) {
+    currentIndex() {
+        return this.animationIndex;
+    }
+
+    domain() {
+        return [0, this.frames.length - 1];
+    }
+
+    speed(s?: number) {
+        if (s != undefined) {
+            this.speedProperty.set(s);
+            this.defaultSpeed = s;
+            this.animationSpeed = s;
+        }
+
+        return this.defaultSpeed;
+    }
+
+    setIndex(i: number) {
+        this.pause();
+        this.animationIndex = i;
+        this.animationSpeed = 50;
+        this.throttleRender();
+    }
+
+    visible() {
+        return this.frames.length > 1;
+    }
+
+    render() {
+        if (this.animationIndex >= this.frames.length) {
+            this.animationIndex = 0;
+        }
+
+        const frame = this.frames[this.animationIndex];
+        if (!frame.bubbles) {
+            frame.bubbles = frame.bubbleFactory();
+        }
+
+        this.renderFrame(
+            (frame as Frame) || { name: "", bubbles: [] },
+            this.animationSpeed
+        );
+    }
+
+    private pause() {
+        this.playing = false;
+        clearTimeout(this.timer);
+    }
+
+    private play() {
+        this.playing = true;
+        this.render();
+        let instance = this;
+        this.timer = setTimeout(async function next() {
+            if (!instance.playing) {
                 return;
             }
 
             await continueOnIdle();
-            animationIndex++;
+            instance.animationIndex++;
 
-            render();
-            timer = setTimeout(next, speed);
-        }, speed);
-    }
-
-    return instance;
-}
-
-function showSpeedSlider(animation: AnimationControl) {
-    let times = [0.1, 0.3, 0.5, 1, 3, 5, 10].reverse();
-    function toTime(index: number) {
-        return (
-            1000 *
-            (index >= 0 ? times[index] || times[times.length - 1] : times[0])
-        );
-    }
-    function toIndex(time: number) {
-        for (var i = 0; i < times.length; i++) {
-            if (time / 1000 >= times[i]) {
-                return i;
-            }
-        }
-
-        return 0;
-    }
-
-    let current = document.getElementById("animationSpeedSlider");
-    if (current) {
-        document.body.removeChild(current);
-        document.body.removeChild(
-            document.getElementById("animationSpeedLabel")!
-        );
-        return;
-    }
-
-    let input = document.createElement("input");
-    input.id = "animationSpeedSlider";
-    input.type = "range";
-    input.style.bottom = speedButtonSize + padding + "px";
-    input["max"] = "0";
-    input["max"] = String(times.length - 1);
-    input.value = String(toIndex(animation.speed()));
-    document.body.appendChild(input);
-
-    let label = document.createElement("label");
-    label.htmlFor = "animationSpeedSlider";
-    label.id = "animationSpeedLabel";
-    label.style.bottom = speedButtonSize + 2 * padding + 100 + "px";
-    label.textContent = `${toTime(Number(input.value)) / 1000}s`;
-    document.body.appendChild(label);
-
-    input.oninput = function () {
-        label.textContent = `${toTime(Number(input.value)) / 1000}s`;
-    };
-
-    input.onchange = function () {
-        document.body.removeChild(input);
-        document.body.removeChild(label);
-        animation.speed(toTime(Number(input.value)));
-    };
-}
-
-export function renderAnimationControl(
-    animation: AnimationControl,
-    animationControlArea: { width: number },
-    context: d3.Selection<SVGGElement, unknown, HTMLElement, any>
-) {
-    // render animation scale
-    let animationScale = d3
-        .scaleLinear()
-        .domain(animation.domain())
-        .range([0, animationControlArea.width])
-        .clamp(true);
-
-    animationScale.range([
-        0 + playButtonSize + padding,
-        animationControlArea.width - speedButtonSize - padding,
-    ]);
-
-    let playButton: any = context.select("svg");
-    setPlaying(animation.isPlaying());
-
-    var dispatch = d3.dispatch("sliderChange");
-
-    let animationSpeedButton = context.select<SVGGElement>("#animationSpeed");
-    if (animationSpeedButton.empty()) {
-        animationSpeedButton = context.append("g");
-        animationSpeedButton
-            .attr("id", "animationSpeed")
-            .node()!
-            .append(animationSpeedButtonSvg);
-    }
-
-    animationSpeedButton
-        .attr(
-            "transform",
-            `translate(${animationScale.range()[1] + padding} 0)`
-        )
-        .attr("width", speedButtonSize)
-        .attr("height", speedButtonSize)
-        .attr("class", "animationSpeed")
-        .on("click", () => showSpeedSlider(animation));
-
-    let animationSlider = context.select<SVGRectElement>("#animationSlider");
-
-    if (animationSlider.empty()) {
-        animationSlider = context.append("rect").attr("id", "animationSlider");
-    }
-    animationSlider
-        .attr("x", animationScale(0) || 0)
-        .attr("y", progressX)
-        .attr(
-            "width",
-            Math.max(0, animationScale.range()[1] - animationScale.range()[0])
-        )
-        .attr("height", 8)
-        .attr("class", "animation-tray")
-        .on("click", sliderclick)
-        .call(
-            d3
-                .drag<SVGRectElement, any>()
-                .on("start", function () {
-                    dispatch.call(
-                        "sliderChange",
-                        this,
-                        Math.round(
-                            animationScale.invert(
-                                d3.mouse(animationSlider.node()!)[0]
-                            )
-                        )
-                    );
-
-                    d3.event.sourceEvent.preventDefault();
-                })
-                .on("drag", function () {
-                    dispatch.call(
-                        "sliderChange",
-                        this,
-                        Math.round(
-                            animationScale.invert(
-                                d3.mouse(animationSlider.node()!)[0]
-                            )
-                        )
-                    );
-                })
-        );
-
-    dispatch.on("sliderChange.slider", function (value) {
-        setSliderValue(value);
-        animation.setIndex(value);
-    });
-
-    let animationIndicator = context.select<SVGRectElement>(
-        "#animationIndicator"
-    );
-    if (animationIndicator.empty()) {
-        animationIndicator = context
-            .append("rect")
-            .attr("id", "animationIndicator");
-    }
-
-    animationIndicator
-        .attr("x", animationScale(0) || 0)
-        .attr("y", progressX)
-        .attr(
-            "width",
-            Math.max(
-                0,
-                animationScale(animation.currentIndex())! - animationScale(0)!
-            )
-        )
-        .attr("height", 8)
-        .attr("class", "animation-indicator");
-
-    let animationHandle = context.select<SVGCircleElement>("#animationHandle");
-    if (animationHandle.empty()) {
-        animationHandle = context
-            .append("circle")
-            .attr("id", "animationHandle");
-    }
-
-    animationHandle
-        .attr("cy", progressX + 4)
-        .attr("cx", animationScale(animation.currentIndex()) || 0)
-        .attr("r", 6)
-        .attr("class", "animation-handle");
-
-    function sliderclick() {
-        let animationIndex = Math.round(
-            animationScale.invert(d3.mouse(animationSlider.node()!)[0])
-        );
-
-        animation.setIndex(animationIndex);
-    }
-
-    function setPlaying(isPlaying: boolean) {
-        let svg = (!isPlaying ? playButtonSvg : pauseButtonSvg)?.cloneNode(
-            true
-        );
-
-        if (playButton.empty()) {
-            context.attr("id", "playButton").node()!.append(svg);
-        } else {
-            context.select<SVGElement>("svg").node()!.replaceWith(svg);
-        }
-
-        playButton = context.select("svg");
-        playButton
-            .attr("x", 0)
-            .attr("y", (speedButtonSize - playButtonSize) / 2)
-            .attr("height", playButtonSize)
-            .attr("width", playButtonSize)
-            .attr("class", "playbutton")
-            .on("click", playClicked);
-    }
-
-    function playClicked() {
-        animation.isPlaying(!animation.isPlaying());
-    }
-
-    function setSliderValue(value: number, transitionduration = 0) {
-        animationIndicator
-            .attr("aria-labelledby", value)
-            .transition()
-            .ease(d3.easeLinear)
-            .duration(transitionduration)
-            .attr(
-                "width",
-                Math.max(
-                    0,
-                    (animationScale(value) || 0) - (animationScale(0) || 0)
-                )
-            );
-        animationHandle
-            .attr("aria-labelledby", value)
-            .transition()
-            .ease(d3.easeLinear)
-            .duration(transitionduration)
-            .attr("cx", animationScale(value) || 0);
+            instance.render();
+            instance.timer = setTimeout(next, instance.animationSpeed);
+        }, this.animationSpeed);
     }
 }

--- a/catalog/animated-bubble-chart/src/animationControl.ts
+++ b/catalog/animated-bubble-chart/src/animationControl.ts
@@ -1,5 +1,7 @@
 import * as d3 from "d3";
+import { Frame, FrameFactory } from "./index";
 import { continueOnIdle } from "./interactionLock";
+import { throttle } from "./modutils";
 
 const playButtonSvg = document.querySelector("#play_button")?.lastChild!;
 const pauseButtonSvg = document.querySelector("#pause_button")?.lastChild!;
@@ -13,309 +15,347 @@ const speedButtonSize = 24,
     progressX =
         (Math.max(speedButtonSize, playButtonSize) - progressHeight) / 2;
 
+type Setup = (animationControl: AnimationControl) => Render;
+type Render = (frame: Frame, animationSpeed: number) => void;
+
+export interface AnimationControl {
+    update(frames: FrameFactory[], onRender: Setup): void;
+    setIndex(index: number): void;
+
+    visible(): boolean;
+    isPlaying(): boolean;
+    isPlaying(playing: boolean): void;
+    speed(): number;
+    speed(s: number): void;
+    domain(): [number, number];
+    currentIndex(): number;
+}
+
 export function animationControl(animationSpeedProperty: {
     set: (value: number) => void;
-}) {
-    let animationScale: d3.ScaleLinear<number, number>;
-    let valueChanged: (value: number, changedByUser: boolean) => void;
-    let animationSpeed: number;
+}): AnimationControl {
+    let frames: FrameFactory[] = [];
+    let onRender: Render = () => {};
+    let throttleRender = throttle(render);
 
     let animationIndex = 0;
-    let range: number[];
+    let speed = 500;
+    let defaultSpeed = 500;
     let playing = false;
-    let animationMax: number;
+    let timer: any = null;
 
-    return {
-        render,
-        update(
-            _animationScale: d3.ScaleLinear<number, number>,
-            _valueChanged: (value: number, changedByUser: boolean) => void,
-            _animationSpeed: number
-        ) {
-            animationScale = _animationScale;
-            valueChanged = _valueChanged;
-            animationSpeed = _animationSpeed;
-
-            range = animationScale.range();
-            animationMax = animationScale.domain()[1];
-            if (animationIndex != 0) {
-                animationIndex = Math.min(animationIndex, animationMax);
-            }
+    let instance: AnimationControl = {
+        update(_frames: FrameFactory[], setupVisualization) {
+            frames = _frames;
+            onRender = setupVisualization(instance);
+            render();
         },
-        getIndex() {
+        isPlaying(setter?: boolean) {
+            if (setter != undefined) {
+                speed = defaultSpeed;
+                if (setter) {
+                    play();
+                } else {
+                    pause();
+                }
+                throttleRender();
+            }
+
+            return playing;
+        },
+        currentIndex() {
             return animationIndex;
         },
-        isPlaying() {
-            return playing;
+        domain() {
+            return [0, frames.length - 1];
+        },
+        speed(s?: number) {
+            if (s != undefined) {
+                animationSpeedProperty.set(s);
+                defaultSpeed = s;
+                speed = s;
+            }
+
+            return defaultSpeed;
+        },
+        setIndex(i) {
+            pause();
+            animationIndex = i;
+            speed = 50;
+            throttleRender();
+        },
+        visible() {
+            return frames.length > 1;
         },
     };
 
-    function showSpeedSlider() {
-        let times = [0.1, 0.3, 0.5, 1, 3, 5, 10].reverse();
-        function toTime(index: number) {
-            return (
-                1000 *
-                (index >= 0
-                    ? times[index] || times[times.length - 1]
-                    : times[0])
-            );
-        }
-        function toIndex(time: number) {
-            for (var i = 0; i < times.length; i++) {
-                if (time / 1000 >= times[i]) {
-                    return i;
-                }
-            }
-
-            return 0;
+    function render() {
+        if (animationIndex >= frames.length) {
+            animationIndex = 0;
         }
 
-        let current = document.getElementById("animationSpeedSlider");
-        if (current) {
-            document.body.removeChild(current);
-            document.body.removeChild(
-                document.getElementById("animationSpeedLabel")!
-            );
-            return;
+        const frame = frames[animationIndex];
+        if(!frame.bubbles) {
+            frame.bubbles =  frame.bubbleFactory();
         }
 
-        let input = document.createElement("input");
-        input.id = "animationSpeedSlider";
-        input.type = "range";
-        input.style.bottom = speedButtonSize + padding + "px";
-        input["max"] = "0";
-        input["max"] = String(times.length - 1);
-        input.value = String(toIndex(animationSpeed));
-        document.body.appendChild(input);
-
-        let label = document.createElement("label");
-        label.htmlFor = "animationSpeedSlider";
-        label.id = "animationSpeedLabel";
-        label.style.bottom = speedButtonSize + 2 * padding + 100 + "px";
-        label.textContent = `${toTime(Number(input.value)) / 1000}s`;
-        document.body.appendChild(label);
-
-        input.oninput = function () {
-            label.textContent = `${toTime(Number(input.value)) / 1000}s`;
-        };
-
-        input.onchange = function () {
-            document.body.removeChild(input);
-            document.body.removeChild(label);
-            animationSpeedProperty.set(toTime(Number(input.value)));
-        };
+        onRender((frame as Frame) || { name: "", bubbles: [] }, speed);
     }
 
-    function render(
-        context: d3.Selection<SVGGElement, unknown, HTMLElement, any>
-    ) {
-        animationScale.range([
-            range[0] + playButtonSize + padding,
-            range[1] - speedButtonSize - padding,
-        ]);
+    function pause() {
+        playing = false;
+        clearTimeout(timer);
+    }
 
-        let playButton: any = context.select("svg");
-        setPlaying(playing);
-
-        var dispatch = d3.dispatch("sliderChange");
-
-        let animationSpeedButton = context.select<SVGGElement>(
-            "#animationSpeed"
-        );
-        if (animationSpeedButton.empty()) {
-            animationSpeedButton = context.append("g");
-            animationSpeedButton
-                .attr("id", "animationSpeed")
-                .node()!
-                .append(animationSpeedButtonSvg);
-        }
-
-        animationSpeedButton
-            .attr(
-                "transform",
-                `translate(${animationScale.range()[1] + padding} 0)`
-            )
-            .attr("width", speedButtonSize)
-            .attr("height", speedButtonSize)
-            .attr("class", "animationSpeed")
-            .on("click", showSpeedSlider);
-
-        let animationSlider = context.select<SVGRectElement>(
-            "#animationSlider"
-        );
-
-        if (animationSlider.empty()) {
-            animationSlider = context
-                .append("rect")
-                .attr("id", "animationSlider");
-        }
-        animationSlider
-            .attr("x", animationScale(0) || 0)
-            .attr("y", progressX)
-            .attr(
-                "width",
-                Math.max(
-                    0,
-                    animationScale.range()[1] - animationScale.range()[0]
-                )
-            )
-            .attr("height", 8)
-            .attr("class", "animation-tray")
-            .on("click", sliderclick)
-            .call(
-                d3
-                    .drag<SVGRectElement, any>()
-                    .on("start", function () {
-                        dispatch.call(
-                            "sliderChange",
-                            this,
-                            Math.round(
-                                animationScale.invert(
-                                    d3.mouse(animationSlider.node()!)[0]
-                                )
-                            )
-                        );
-
-                        d3.event.sourceEvent.preventDefault();
-                    })
-                    .on("drag", function () {
-                        dispatch.call(
-                            "sliderChange",
-                            this,
-                            Math.round(
-                                animationScale.invert(
-                                    d3.mouse(animationSlider.node()!)[0]
-                                )
-                            )
-                        );
-                    })
-            );
-
-        dispatch.on("sliderChange.slider", function (value) {
-            setSliderValue(value);
-            animationIndex = value;
-            valueChanged(value, true);
-        });
-
-        let animationIndicator = context.select<SVGRectElement>(
-            "#animationIndicator"
-        );
-        if (animationIndicator.empty()) {
-            animationIndicator = context
-                .append("rect")
-                .attr("id", "animationIndicator");
-        }
-
-        animationIndicator
-            .attr("x", animationScale(0) || 0)
-            .attr("y", progressX)
-            .attr(
-                "width",
-                Math.max(
-                    0,
-                    animationScale(animationIndex)! - animationScale(0)!
-                )
-            )
-            .attr("height", 8)
-            .attr("class", "animation-indicator");
-
-        let animationHandle = context.select<SVGCircleElement>(
-            "#animationHandle"
-        );
-        if (animationHandle.empty()) {
-            animationHandle = context
-                .append("circle")
-                .attr("id", "animationHandle");
-        }
-
-        animationHandle
-            .attr("cy", progressX + 4)
-            .attr("cx", animationScale(animationIndex) || 0)
-            .attr("r", 6)
-            .attr("class", "animation-handle");
-
-        function sliderclick() {
-            setPlaying(false);
-            animationIndex = Math.round(
-                animationScale.invert(d3.mouse(animationSlider.node()!)[0])
-            );
-            setSliderValue(animationIndex);
-            valueChanged(animationIndex, true);
-        }
-
-        function setPlaying(isPlaying: boolean) {
-            playing = isPlaying;
-            let svg = (!isPlaying ? playButtonSvg : pauseButtonSvg)?.cloneNode(
-                true
-            );
-
-            if (playButton.empty()) {
-                context.attr("id", "playButton").node()!.append(svg);
-            } else {
-                context.select<SVGElement>("svg").node()!.replaceWith(svg);
-            }
-
-            playButton = context.select("svg");
-            playButton
-                .attr("x", 0)
-                .attr("y", (speedButtonSize - playButtonSize) / 2)
-                .attr("height", playButtonSize)
-                .attr("width", playButtonSize)
-                .attr("class", "playbutton")
-                .on("click", playClicked);
-        }
-
-        function playClicked() {
-            if (!playing) {
-                // Reset to start when clicking play if the animation has reached the end.
-                if (animationIndex >= animationMax) {
-                    animationIndex = 0;
-                }
-
-                setPlaying(true);
-                d3.timeout(play, 100);
-            } else {
-                setPlaying(false);
-            }
-        }
-
-        async function play() {
+    function play() {
+        playing = true;
+        render();
+        timer = setTimeout(async function next() {
             if (!playing) {
                 return;
             }
 
-            if (animationIndex <= animationMax) {
-                await continueOnIdle();
+            await continueOnIdle();
+            animationIndex++;
 
-                setSliderValue(animationIndex, animationSpeed);
-                valueChanged(animationIndex, false);
+            render();
+            timer = setTimeout(next, speed);
+        }, speed);
+    }
 
-                animationIndex += 1;
-                d3.timeout(play, animationSpeed);
-            } else {
-                setPlaying(false);
+    return instance;
+}
+
+function showSpeedSlider(animation: AnimationControl) {
+    let times = [0.1, 0.3, 0.5, 1, 3, 5, 10].reverse();
+    function toTime(index: number) {
+        return (
+            1000 *
+            (index >= 0 ? times[index] || times[times.length - 1] : times[0])
+        );
+    }
+    function toIndex(time: number) {
+        for (var i = 0; i < times.length; i++) {
+            if (time / 1000 >= times[i]) {
+                return i;
             }
         }
 
-        function setSliderValue(value: number, transitionduration = 0) {
-            animationIndicator
-                .attr("aria-labelledby", value)
-                .transition()
-                .ease(d3.easeLinear)
-                .duration(transitionduration)
-                .attr(
-                    "width",
-                    Math.max(
-                        0,
-                        (animationScale(value) || 0) - (animationScale(0) || 0)
-                    )
-                );
-            animationHandle
-                .attr("aria-labelledby", value)
-                .transition()
-                .ease(d3.easeLinear)
-                .duration(transitionduration)
-                .attr("cx", animationScale(value) || 0);
+        return 0;
+    }
+
+    let current = document.getElementById("animationSpeedSlider");
+    if (current) {
+        document.body.removeChild(current);
+        document.body.removeChild(
+            document.getElementById("animationSpeedLabel")!
+        );
+        return;
+    }
+
+    let input = document.createElement("input");
+    input.id = "animationSpeedSlider";
+    input.type = "range";
+    input.style.bottom = speedButtonSize + padding + "px";
+    input["max"] = "0";
+    input["max"] = String(times.length - 1);
+    input.value = String(toIndex(animation.speed()));
+    document.body.appendChild(input);
+
+    let label = document.createElement("label");
+    label.htmlFor = "animationSpeedSlider";
+    label.id = "animationSpeedLabel";
+    label.style.bottom = speedButtonSize + 2 * padding + 100 + "px";
+    label.textContent = `${toTime(Number(input.value)) / 1000}s`;
+    document.body.appendChild(label);
+
+    input.oninput = function () {
+        label.textContent = `${toTime(Number(input.value)) / 1000}s`;
+    };
+
+    input.onchange = function () {
+        document.body.removeChild(input);
+        document.body.removeChild(label);
+        animation.speed(toTime(Number(input.value)));
+    };
+}
+
+export function renderAnimationControl(
+    animation: AnimationControl,
+    animationControlArea: { width: number },
+    context: d3.Selection<SVGGElement, unknown, HTMLElement, any>
+) {
+    // render animation scale
+    let animationScale = d3
+        .scaleLinear()
+        .domain(animation.domain())
+        .range([0, animationControlArea.width])
+        .clamp(true);
+
+    animationScale.range([
+        0 + playButtonSize + padding,
+        animationControlArea.width - speedButtonSize - padding,
+    ]);
+
+    let playButton: any = context.select("svg");
+    setPlaying(animation.isPlaying());
+
+    var dispatch = d3.dispatch("sliderChange");
+
+    let animationSpeedButton = context.select<SVGGElement>("#animationSpeed");
+    if (animationSpeedButton.empty()) {
+        animationSpeedButton = context.append("g");
+        animationSpeedButton
+            .attr("id", "animationSpeed")
+            .node()!
+            .append(animationSpeedButtonSvg);
+    }
+
+    animationSpeedButton
+        .attr(
+            "transform",
+            `translate(${animationScale.range()[1] + padding} 0)`
+        )
+        .attr("width", speedButtonSize)
+        .attr("height", speedButtonSize)
+        .attr("class", "animationSpeed")
+        .on("click", () => showSpeedSlider(animation));
+
+    let animationSlider = context.select<SVGRectElement>("#animationSlider");
+
+    if (animationSlider.empty()) {
+        animationSlider = context.append("rect").attr("id", "animationSlider");
+    }
+    animationSlider
+        .attr("x", animationScale(0) || 0)
+        .attr("y", progressX)
+        .attr(
+            "width",
+            Math.max(0, animationScale.range()[1] - animationScale.range()[0])
+        )
+        .attr("height", 8)
+        .attr("class", "animation-tray")
+        .on("click", sliderclick)
+        .call(
+            d3
+                .drag<SVGRectElement, any>()
+                .on("start", function () {
+                    dispatch.call(
+                        "sliderChange",
+                        this,
+                        Math.round(
+                            animationScale.invert(
+                                d3.mouse(animationSlider.node()!)[0]
+                            )
+                        )
+                    );
+
+                    d3.event.sourceEvent.preventDefault();
+                })
+                .on("drag", function () {
+                    dispatch.call(
+                        "sliderChange",
+                        this,
+                        Math.round(
+                            animationScale.invert(
+                                d3.mouse(animationSlider.node()!)[0]
+                            )
+                        )
+                    );
+                })
+        );
+
+    dispatch.on("sliderChange.slider", function (value) {
+        setSliderValue(value);
+        animation.setIndex(value);
+    });
+
+    let animationIndicator = context.select<SVGRectElement>(
+        "#animationIndicator"
+    );
+    if (animationIndicator.empty()) {
+        animationIndicator = context
+            .append("rect")
+            .attr("id", "animationIndicator");
+    }
+
+    animationIndicator
+        .attr("x", animationScale(0) || 0)
+        .attr("y", progressX)
+        .attr(
+            "width",
+            Math.max(
+                0,
+                animationScale(animation.currentIndex())! - animationScale(0)!
+            )
+        )
+        .attr("height", 8)
+        .attr("class", "animation-indicator");
+
+    let animationHandle = context.select<SVGCircleElement>("#animationHandle");
+    if (animationHandle.empty()) {
+        animationHandle = context
+            .append("circle")
+            .attr("id", "animationHandle");
+    }
+
+    animationHandle
+        .attr("cy", progressX + 4)
+        .attr("cx", animationScale(animation.currentIndex()) || 0)
+        .attr("r", 6)
+        .attr("class", "animation-handle");
+
+    function sliderclick() {
+        let animationIndex = Math.round(
+            animationScale.invert(d3.mouse(animationSlider.node()!)[0])
+        );
+
+        animation.setIndex(animationIndex);
+    }
+
+    function setPlaying(isPlaying: boolean) {
+        let svg = (!isPlaying ? playButtonSvg : pauseButtonSvg)?.cloneNode(
+            true
+        );
+
+        if (playButton.empty()) {
+            context.attr("id", "playButton").node()!.append(svg);
+        } else {
+            context.select<SVGElement>("svg").node()!.replaceWith(svg);
         }
+
+        playButton = context.select("svg");
+        playButton
+            .attr("x", 0)
+            .attr("y", (speedButtonSize - playButtonSize) / 2)
+            .attr("height", playButtonSize)
+            .attr("width", playButtonSize)
+            .attr("class", "playbutton")
+            .on("click", playClicked);
+    }
+
+    function playClicked() {
+        animation.isPlaying(!animation.isPlaying());
+    }
+
+    function setSliderValue(value: number, transitionduration = 0) {
+        animationIndicator
+            .attr("aria-labelledby", value)
+            .transition()
+            .ease(d3.easeLinear)
+            .duration(transitionduration)
+            .attr(
+                "width",
+                Math.max(
+                    0,
+                    (animationScale(value) || 0) - (animationScale(0) || 0)
+                )
+            );
+        animationHandle
+            .attr("aria-labelledby", value)
+            .transition()
+            .ease(d3.easeLinear)
+            .duration(transitionduration)
+            .attr("cx", animationScale(value) || 0);
     }
 }

--- a/catalog/animated-bubble-chart/src/animationControl.ts
+++ b/catalog/animated-bubble-chart/src/animationControl.ts
@@ -2,7 +2,6 @@ import { Frame, FrameFactory } from "./index";
 import { continueOnIdle } from "./interactionLock";
 import { throttle } from "./modutils";
 
-
 type SetupVisualization = (animationControl: AnimationControl) => RenderFrame;
 type RenderFrame = (frame: Frame, animationSpeed: number) => void;
 
@@ -72,19 +71,23 @@ export class AnimationControl {
     }
 
     render() {
+        const emptyFrame = { name: "", bubbles: [] };
+
         if (this.animationIndex >= this.frames.length) {
             this.animationIndex = 0;
         }
 
         const frame = this.frames[this.animationIndex];
+        if (!frame) {
+            this.renderFrame(emptyFrame, 0);
+            return;
+        }
+
         if (!frame.bubbles) {
             frame.bubbles = frame.bubbleFactory();
         }
 
-        this.renderFrame(
-            (frame as Frame) || { name: "", bubbles: [] },
-            this.animationSpeed
-        );
+        this.renderFrame((frame as Frame) || emptyFrame, this.animationSpeed);
     }
 
     private pause() {

--- a/catalog/animated-bubble-chart/src/animationControl.ts
+++ b/catalog/animated-bubble-chart/src/animationControl.ts
@@ -95,7 +95,15 @@ export class AnimationControl {
         clearTimeout(this.timer);
     }
 
+    private isAtLastFrame() {
+        return this.animationIndex == this.frames.length - 1;
+    }
+
     private play() {
+        if (this.isAtLastFrame()) {
+            this.animationIndex = 0;
+        }
+
         this.playing = true;
         this.render();
         let instance = this;
@@ -105,7 +113,11 @@ export class AnimationControl {
             }
 
             await continueOnIdle();
-            instance.animationIndex++;
+            if (instance.isAtLastFrame()) {
+                instance.pause();
+            } else {
+                instance.animationIndex++;
+            }
 
             instance.render();
             instance.timer = setTimeout(next, instance.animationSpeed);

--- a/catalog/animated-bubble-chart/src/canvas.ts
+++ b/catalog/animated-bubble-chart/src/canvas.ts
@@ -1,5 +1,0 @@
-/**
- * This file is responsible for rendering the bubbles onto the screen.
- */
-
-

--- a/catalog/animated-bubble-chart/src/canvas.ts
+++ b/catalog/animated-bubble-chart/src/canvas.ts
@@ -1,0 +1,5 @@
+/**
+ * This file is responsible for rendering the bubbles onto the screen.
+ */
+
+

--- a/catalog/animated-bubble-chart/src/index.ts
+++ b/catalog/animated-bubble-chart/src/index.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { Size } from "spotfire-api";
-import { highlight, markingHandler, markRowforAllTimes } from "./modutils";
+import { highlight, markingHandler } from "./modutils";
 import { Grid } from "./Grid";
 import { AnimationControl } from "./animationControl";
 
@@ -103,8 +103,9 @@ export interface Bubble {
     color: string;
     id: string;
     label: string;
+    tooltip: string;
     isMarked: boolean;
-    mark(): void;
+    mark(toggle?: boolean): void;
 }
 
 export interface FrameFactory {
@@ -132,7 +133,6 @@ export function render(
     },
     animationControl: AnimationControl,
     windowSize: Size,
-    toolTipDisplayAxes: Spotfire.Axis[],
     mod: Spotfire.Mod,
     showLabels: boolean,
     xLogScale: boolean,
@@ -378,7 +378,7 @@ export function render(
         let opacity = allOrNoneMarked ? defaultOpacity : markingOpacity;
 
         // prepare the tooltip
-        let hl = highlight(mod, toolTipDisplayAxes);
+        let hl = highlight(mod);
 
         markerLayer.attr(
             "transform",
@@ -458,18 +458,13 @@ export function render(
                 .attr("r", radius)
                 .style("fill", (row: Bubble) => row.color)
                 .end()
-                .catch(() => {                    
+                .catch(() => {
                     // Interrupted transitions lead to a rejected promise.
                 });
 
             allDots
                 .on("click", function (row: Bubble) {
-                    markRowforAllTimes(
-                        row,
-                        dataView,
-                        d3.event.ctrlKey || d3.event.metaKey
-                    );
-
+                    row.mark(d3.event.ctrlKey || d3.event.metaKey);
                     d3.event.preventDefault();
                 })
                 .call(hl);

--- a/catalog/animated-bubble-chart/src/index.ts
+++ b/catalog/animated-bubble-chart/src/index.ts
@@ -3,7 +3,6 @@ import { Size } from "spotfire-api";
 import { highlight, markingHandler, markRowforAllTimes } from "./modutils";
 import { Grid } from "./Grid";
 import { AnimationControl } from "./animationControl";
-import { setIdle } from "./interactionLock";
 
 /**
  * Constants
@@ -439,7 +438,7 @@ export function render(
             let allDots = dots.merge(newdots);
 
             // update attributes on all dots
-            let transitionEnd = allDots
+            allDots
                 .attr("id", getKey)
                 .attr("class", (r) => `dot ${r.isMarked ? "marked" : ""}`)
                 .call(
@@ -459,13 +458,12 @@ export function render(
                 .attr("r", radius)
                 .style("fill", (row: Bubble) => row.color)
                 .end()
-                .catch(() => {
+                .catch(() => {                    
                     // Interrupted transitions lead to a rejected promise.
                 });
 
             allDots
                 .on("click", function (row: Bubble) {
-                    setIdle();
                     markRowforAllTimes(
                         row,
                         dataView,
@@ -486,7 +484,6 @@ export function render(
                 .style("fill-opacity", 0)
                 .attr("r", 0)
                 .remove();
-            return transitionEnd;
         }
 
         function radius(row: Bubble) {

--- a/catalog/animated-bubble-chart/src/main.ts
+++ b/catalog/animated-bubble-chart/src/main.ts
@@ -1,4 +1,5 @@
-import { clearCanvas, render } from "./index";
+import { DataViewRow } from "spotfire-api";
+import { Bubble, clearCanvas, render } from "./index";
 import { continueOnIdle } from "./interactionLock";
 import { createLabelPopout } from "./popout";
 
@@ -47,9 +48,111 @@ window.Spotfire.initialize(async (mod) => {
                     mod.controls.errorOverlay.show(errors, "DataView");
                 } else {
                     mod.controls.errorOverlay.hide("DataView");
+                    mod.controls.errorOverlay.hide("General");
+
+                    const hasX = !!(await dataView.continuousAxis("X"));
+                    const hasY = !!(await dataView.continuousAxis("Y"));
+                    const hasSize = !!(await dataView.continuousAxis("Size"));
+
+                    async function minMax(axisName: string) {
+                        if (!(await dataView.continuousAxis(axisName))) {
+                            return { min: 0, max: 0 };
+                        }
+
+                        let min = Infinity;
+                        let max = -Infinity;
+
+                        for (const row of (await dataView.allRows()) || []) {
+                            let v =
+                                row.continuous<number>(axisName).value() || 0;
+                            if (v < min) {
+                                min = v;
+                            }
+
+                            if (v > max) {
+                                max = v;
+                            }
+                        }
+
+                        return { min, max };
+                    }
+
+                    let animateLeaves =
+                        (
+                            await (
+                                await dataView.hierarchy("AnimateBy")
+                            )?.root()
+                        )?.leaves() || [];
+
+                    let bubbles = animateLeaves[0]
+                        .rows()
+                        .filter(rowFilter)
+                        .sort(sortContinuousAxis("Size"))
+                        .map(rowToBubble);
+
+                    /** Filter out rows that can't be visualized.
+                     * This includes null values and 0 for log scales */
+                    function rowFilter(row: Spotfire.DataViewRow) {
+                        if (
+                            !hasX ||
+                            (xLogScale && !row.continuous("X").value()) ||
+                            row.continuous("X").value() == null
+                        ) {
+                            return false;
+                        }
+
+                        if (
+                            !hasY ||
+                            (yLogScale && !row.continuous("Y").value()) ||
+                            row.continuous("Y").value() == null
+                        ) {
+                            return false;
+                        }
+
+                        return true;
+                    }
+
+                    /**
+                     * Sort large bubbles at the back
+                     */
+                    function sortContinuousAxis(
+                        axisName: string
+                    ): (a: DataViewRow, b: DataViewRow) => number {
+                        return (a, b) =>
+                            (b.continuous<number>(axisName).value() || 0) -
+                            (a.continuous<number>(axisName).value() || 0);
+                    }
+
+                    function rowToBubble(row: DataViewRow): Bubble {
+                        return {
+                            id: row.elementId(false, ["AnimateBy"]),
+                            x: hasX
+                                ? row.continuous<number>("X").value() || 0
+                                : 0,
+                            y: hasY
+                                ? row.continuous<number>("Y").value() || 0
+                                : 0,
+                            size: hasSize
+                                ? row.continuous<number>("Size").value() || 0
+                                : 0,
+                            label: row.leafNode("MarkerBy")!.formattedPath(),
+                            isMarked: row.isMarked(),
+                            color: row.color().hexCode,
+                            mark() {},
+                        };
+                    }
+
+                    let scales = {
+                        x: await minMax("X"),
+                        y: await minMax("Y"),
+                        size: await minMax("Size"),
+                    };
 
                     await render(
                         dataView,
+                        bubbles,
+                        scales,
+                        true,
                         windowSize,
                         axes,
                         mod,

--- a/catalog/animated-bubble-chart/src/main.ts
+++ b/catalog/animated-bubble-chart/src/main.ts
@@ -1,5 +1,5 @@
 import { DataViewRow } from "spotfire-api";
-import { animationControl } from "./animationControl";
+import { AnimationControl } from "./animationControl";
 import { Bubble, clearCanvas, render } from "./index";
 import { continueOnIdle } from "./interactionLock";
 import { createLabelPopout } from "./popout";
@@ -25,7 +25,7 @@ window.Spotfire.initialize(async (mod) => {
         mod.visualization.axis("Size")
     );
 
-    let ac = animationControl(animationSpeedProperty);
+    let ac = new AnimationControl(animationSpeedProperty);
 
     /**
      * Creates a function that is part of the main read-render loop.
@@ -158,8 +158,8 @@ window.Spotfire.initialize(async (mod) => {
                         axisName: string
                     ): (a: DataViewRow, b: DataViewRow) => number {
                         return (a, b) =>
-                            (b.continuous<number>(axisName).value() || 0) -
-                            (a.continuous<number>(axisName).value() || 0);
+                            hasSize ?  (b.continuous<number>(axisName).value() || 0) -
+                            (a.continuous<number>(axisName).value() || 0) : 1;
                     }
                 }
             } catch (e: any) {

--- a/catalog/animated-bubble-chart/src/main.ts
+++ b/catalog/animated-bubble-chart/src/main.ts
@@ -1,7 +1,6 @@
 import { DataViewRow } from "spotfire-api";
 import { AnimationControl } from "./animationControl";
 import { Bubble, clearCanvas, render } from "./index";
-import { continueOnIdle } from "./interactionLock";
 import { createLabelPopout } from "./popout";
 
 window.Spotfire.initialize(async (mod) => {
@@ -42,7 +41,6 @@ window.Spotfire.initialize(async (mod) => {
             animationSpeed,
             ...axes
         ) => {
-            await continueOnIdle();
 
             try {
                 const errors = await dataView.getErrors();

--- a/catalog/animated-bubble-chart/src/modutils.ts
+++ b/catalog/animated-bubble-chart/src/modutils.ts
@@ -1,6 +1,5 @@
 // @ts-ignore
 import * as d3 from "d3";
-import { DataViewRow } from "spotfire-api";
 import { Bubble } from "./index";
 import { setBusy, setIdle } from "./interactionLock";
 
@@ -26,10 +25,10 @@ export function highlight(
 
     /**
      * Show the tooltip
-     * @param {Spotfire.DataViewRow} row
+     * @param {Spotfire.Bubble} row
      * @param {Int} i
      */
-    function showTooltip(this: any, row: DataViewRow) {
+    function showTooltip(this: any, row: Bubble) {
         setBusy();
         d3.select(this)
             .clone()
@@ -38,45 +37,65 @@ export function highlight(
             .style("stroke", "black")
             .classed("highlighter", true);
 
-        let tooltipItems: string[] = [];
-        tooltipDisplayAxes.forEach((axis) => {
-            if (axis.expression == "") {
-                return;
-            }
-            if (axis.expression == "<>") {
-                return;
-            }
+        // let tooltipItems: string[] = [];
+        // tooltipDisplayAxes.forEach((axis) => {
+        //     if (axis.expression == "") {
+        //         return;
+        //     }
+        //     if (axis.expression == "<>") {
+        //         return;
+        //     }
 
-            let tooltipItemText = getDisplayName(axis);
-            tooltipItemText += ": ";
+        //     let tooltipItemText = getDisplayName(axis);
+        //     tooltipItemText += ": ";
 
-            if (axis.isCategorical) {
-                tooltipItemText += row.categorical(axis.name).formattedValue();
-            } else {
-                tooltipItemText += row.continuous(axis.name).formattedValue();
-            }
-            if (!tooltipItems.includes(tooltipItemText)) {
-                tooltipItems.push(tooltipItemText);
-            }
-        });
-        let tooltipText = tooltipItems.join("\n");
+        //     if (axis.isCategorical) {
+        //         tooltipItemText += row.categorical(axis.name).formattedValue();
+        //     } else {
+        //         tooltipItemText += row.continuous(axis.name).formattedValue();
+        //     }
+        //     if (!tooltipItems.includes(tooltipItemText)) {
+        //         tooltipItems.push(tooltipItemText);
+        //     }
+        // });
+        // let tooltipText = tooltipItems.join("\n");
 
-        mod.controls.tooltip.show(tooltipText);
+        mod.controls.tooltip.show(row.label);
     }
 
-    /**
-     *
-     * @param {Spotfire.Axis} axis
-     */
-    function getDisplayName(axis: Spotfire.Axis) {
-        return axis.parts
-            .map((node) => {
-                return node.displayName;
-            })
-            .join();
-    }
+    //     /**
+    //      *
+    //      * @param {Spotfire.Axis} axis
+    //      */
+    //     function getDisplayName(axis: Spotfire.Axis) {
+    //         return axis.parts
+    //             .map((node) => {
+    //                 return node.displayName;
+    //             })
+    //             .join();
+    //     }
 
     return highlight;
+}
+
+export function throttle<T extends Function>(func: T, timeout = 50): T {
+    let timer: any;
+    let cb = () => {};
+    return ((...args: any[]) => {
+        if (!timer) {
+            func.apply(null, args);
+            timer = setTimeout(() => {
+                cb();
+                cb = () => {};
+                timer = null;
+            }, timeout);
+            return;
+        } else {
+            cb = () => {
+                func.apply(null, args);
+            };
+        }
+    }) as any;
 }
 
 // /**
@@ -191,6 +210,7 @@ export async function markRowforAllTimes(
     dataView: Spotfire.DataView,
     toggle: boolean
 ) {
+    row.mark();
     // let mode: Spotfire.MarkingOperation = toggle ? "ToggleOrAdd" : "Replace";
 
     // if (!(await dataView.categoricalAxis("AnimateBy"))) {

--- a/catalog/animated-bubble-chart/src/modutils.ts
+++ b/catalog/animated-bubble-chart/src/modutils.ts
@@ -12,15 +12,22 @@ export function highlight(
     mod: Spotfire.Mod,
     tooltipDisplayAxes: Spotfire.Axis[]
 ) {
+    let timeout: any = null;
+
     function highlight(selection: any) {
         selection.on("mouseenter", showTooltip).on("mouseleave", hideTooltip);
     }
 
     function hideTooltip() {
-        setIdle();
-        // d3.select("#HighlightShape").remove();
-        d3.select(".highlighter").remove();
-        mod.controls.tooltip.hide();
+        d3.selectAll(".highlighter").remove();
+
+        if (!timeout) {
+            timeout = setTimeout(() => {
+                setIdle();
+                mod.controls.tooltip.hide();
+                timeout = null;
+            }, 500);
+        }
     }
 
     /**
@@ -29,12 +36,16 @@ export function highlight(
      * @param {Int} i
      */
     function showTooltip(this: any, row: Bubble) {
+        clearTimeout(timeout);
+        timeout = null;
+        d3.selectAll("svg *").transition().duration(0);
         setBusy();
         d3.select(this)
             .clone()
             .raise()
             .style("fill", "None")
             .style("stroke", "black")
+            .classed("dot", false)
             .classed("highlighter", true);
 
         // let tooltipItems: string[] = [];

--- a/catalog/animated-bubble-chart/src/modutils.ts
+++ b/catalog/animated-bubble-chart/src/modutils.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import * as d3 from "d3";
 import { DataViewRow } from "spotfire-api";
+import { Bubble } from "./index";
 import { setBusy, setIdle } from "./interactionLock";
 
 // /**
@@ -186,30 +187,30 @@ export function markingHandler(
 }
 
 export async function markRowforAllTimes(
-    row: DataViewRow,
+    row: Bubble,
     dataView: Spotfire.DataView,
     toggle: boolean
 ) {
-    let mode: Spotfire.MarkingOperation = toggle ? "ToggleOrAdd" : "Replace";
+    // let mode: Spotfire.MarkingOperation = toggle ? "ToggleOrAdd" : "Replace";
 
-    if (!(await dataView.categoricalAxis("AnimateBy"))) {
-        row.mark(mode);
-    }
+    // if (!(await dataView.categoricalAxis("AnimateBy"))) {
+    //     row.mark();
+    // }
 
-    const axes = (await dataView.axes())
-        .filter((a) => a.isCategorical && a.name != "AnimateBy")
-        .map((a) => a.name);
-    (await dataView.allRows())
-        ?.filter((sibling) => {
-            for (var i = 0; i < axes.length; i++) {
-                if (
-                    row.categorical(axes[i]).leafIndex !=
-                    sibling.categorical(axes[i]).leafIndex
-                ) {
-                    return false;
-                }
-            }
-            return true;
-        })
-        .forEach((r) => r.mark(mode));
+    // const axes = (await dataView.axes())
+    //     .filter((a) => a.isCategorical && a.name != "AnimateBy")
+    //     .map((a) => a.name);
+    // (await dataView.allRows())
+    //     ?.filter((sibling) => {
+    //         for (var i = 0; i < axes.length; i++) {
+    //             if (
+    //                 row.categorical(axes[i]).leafIndex !=
+    //                 sibling.categorical(axes[i]).leafIndex
+    //             ) {
+    //                 return false;
+    //             }
+    //         }
+    //         return true;
+    //     })
+    //     .forEach((r) => r.mark(mode));
 }


### PR DESCRIPTION
This code refactor of the animated bubble chart aims to solve a few issues that are present in the current version. 

**Issues**:
- When the mod is stressed, e.g. by marking very quickly, the rendering code can get out of sync and start reading from a disposed data view. This leads to a blank canvas and it can't recover until it is fully re-rendered.
- The other issue concerns the highlight feature. When the visualization is animating, it is possible to pause the animation by hovering over a circle. The current version does not stop immediately when entering over a circle and it is possible to see a slight shift of the highlight ring and the circle. 

The refactoring solves both these issues.  
- The visualization is no longer rendering `DataViewRow`s. Instead it is rendering a `Frame` with `Bubble`s. The frames are handled by an `AnimationControl`, which is also responsible for the animation speed and the current index.
- The transition effect between frames is paused immediately when hovering over a bubble. The transition starts again after a few hundred milliseconds when leaving the bubble. The small pause is meant to simplify movement between bubbles. 

The code flow is as follows:
- Data and property changes enter into the subscribe loop of main.ts
- Frames are created and passed into the long lived animation control instance. 
- The animation control renders the visualization fully (index.ts:render) when receiving changes from main.ts
- When starting the animation, the animation control will call the update code to only change the position of the bubbles.